### PR TITLE
Move shared logic to a base class

### DIFF
--- a/Cmse_Widget_Base.php
+++ b/Cmse_Widget_Base.php
@@ -1,0 +1,38 @@
+<?php
+
+abstract class Cmse_Widget_Base extends \Elementor\Widget_Base
+{
+    final public function get_name() {
+        $name = str_replace(['Cmse_','_Widget'],'',__CLASS__);
+        return strtolower($name);
+    }
+
+    final public function get_title() {
+        global $cmse;
+        return $cmse('widgetprefix').' '.$this->get_name();
+    }
+
+    final public function get_icon() {
+        return $this->_register_controls()->icon;
+    }
+
+    final public function get_categories() {
+        return [$this->_register_controls()->category];
+    }
+
+    final protected function _register_controls() {
+        $icon = Cmse_Elementor_Widgets::fields($this->get_name(),$this);
+
+        return (object)$icon;
+    }
+
+    // front end output
+    final protected function render() {
+        $v = (object)$this->get_settings_for_display();
+        if( file_exists(__DIR__.'/display.php') ) {
+            include __DIR__.'/display.php';
+        }else{
+            echo 'The display file is missing. Check the widget folder for file display.php at <pre>'.__DIR__.'</pre>';
+        }
+    }
+}

--- a/copy/widget.php
+++ b/copy/widget.php
@@ -5,42 +5,8 @@ defined('ABSPATH') || exit('CMSEnergizer.com');
 Elementor widget: widgetname
 */
 
-class Cmse_widgetname_Widget extends \Elementor\Widget_Base
+class Cmse_widgetname_Widget extends Cmse_Widget_Base
 {
-	public function get_name() {
-		$name = str_replace(['Cmse_','_Widget'],'',__CLASS__);
-		return strtolower($name);
-	}
-	
-	public function get_title() {
-		global $cmse;
-		return $cmse('widgetprefix').' '.$this->get_name();
-	}
-	
-	public function get_icon() {
-		return $this->_register_controls()->icon;
-	}
-	
-	public function get_categories() {
-		return [$this->_register_controls()->category];
-	}
-	
-	protected function _register_controls() {
-		$icon = Cmse_Elementor_Widgets::fields($this->get_name(),$this);
-		
-		return (object)$icon;
-	}
-	
-	// front end output
-	protected function render() {
-		$v = (object)$this->get_settings_for_display();
-		if( file_exists(__DIR__.'/display.php') ) {
-			include __DIR__.'/display.php';
-		}else{
-			echo 'The display file is missing. Check the widget folder for file display.php at <pre>'.__DIR__.'</pre>';
-		}
-	}
-	
 	protected function content_template() {
 	}
 }

--- a/widgetloader.php
+++ b/widgetloader.php
@@ -13,7 +13,8 @@ https://developers.elementor.com/elementor-controls/
 defined('ABSPATH') || exit('CMSEnergizer.com');
 
 // make paths and variable changes in the loaded constants file.
-include_once __DIR__.'/constants.php';
+require_once __DIR__.'/constants.php';
+require_once __DIR__.'/Cmse_Widget_Base.php';
 
 /*--- No need to edit below this line --*/
 


### PR DESCRIPTION
This is in reference to the SO post here: https://stackoverflow.com/a/69878141/231316

This is an example of moving the shared logic to a base class so that only the overridable parts need to be added to the specific classes. I marked the methods as final, which may or may not be a good idea, but it does appear that is all boilerplate.